### PR TITLE
fix: Text Color Code Block Copy Button

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,3 @@
+button[data-testid="copy-code-button"] ~ div {
+  color: black;
+}


### PR DESCRIPTION
1. Added `style.css` to add or override custom classes and styling.
2. Added class to override code blocks copy button text color.
3. Override `.text-white` to color `black` to match odin primary color bg.

### Dark
<img width="499" height="456" alt="Screenshot 2025-07-24 at 2 15 23 PM" src="https://github.com/user-attachments/assets/27e9ca63-cd54-40d2-a8d4-9024ce2a9a67" />

### Light
<img width="446" height="388" alt="Screenshot 2025-07-24 at 2 15 49 PM" src="https://github.com/user-attachments/assets/b428b377-e0ca-4793-be82-51f3dbec3aae" />

