### PR TITLE
Add canister and staking documentation

### DIFF
--- a/demo/sdk/src/services/canister.ts
+++ b/demo/sdk/src/services/canister.ts
@@ -31,7 +31,7 @@ export class CanisterServiceImpl implements CanisterService {
   }
 
   /**
-   * Get or create IC agent with delegation identity
+   * Get or create IC agent withto delegation identity
    */
   private async getAgent(): Promise<HttpAgent> {
     if (!this.agent) {

--- a/docs/canister/access-grant.mdx
+++ b/docs/canister/access-grant.mdx
@@ -1,0 +1,49 @@
+---
+title: "access_grant"
+description: "Grant platform access using an access code"
+---
+
+# access_grant
+
+Grant platform access to the authenticated user using an access code. Access codes may be required during early access or invite-only periods.
+
+## Method Signature
+
+```typescript
+access_grant: ActorMethod<[string], boolean>
+```
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `code` | `string` | Yes | The access code to redeem |
+
+## Response
+
+Returns a `boolean`:
+- `true` - Access granted successfully
+- `false` - Access code is invalid or already used
+
+## Example Usage
+
+### Basic Access Grant
+```typescript
+try {
+  const granted = await actor.access_grant("ACCESS-CODE-123");
+
+  if (granted) {
+    console.log("Access granted! You can now use the platform.");
+  } else {
+    console.log("Invalid or expired access code.");
+  }
+} catch (error) {
+  console.error("Failed to grant access:", error);
+}
+```
+
+## Common Errors
+
+- **Invalid code**: The access code doesn't exist or has expired
+- **Already used**: The code has already been redeemed
+- **Not authenticated**: User must be logged in

--- a/docs/canister/configuration.mdx
+++ b/docs/canister/configuration.mdx
@@ -1,0 +1,196 @@
+---
+title: "Configuration Reference"
+description: "All canister IDs, API endpoints, and environment configuration"
+---
+
+# Configuration Reference
+
+Complete reference of all canister IDs, API endpoints, and IC host configuration across environments.
+
+## Canister IDs
+
+### Odin Trading Canister (Main)
+
+The primary canister for trading, token creation, liquidity, transfers, and withdrawals.
+
+| Environment | Canister ID |
+|-------------|-------------|
+| Development | `w5cxm-6iaaa-aaaaj-az4jq-cai` |
+| Staging | `z2vm5-gaaaa-aaaaj-azw6q-cai` |
+| Production | `z2vm5-gaaaa-aaaaj-azw6q-cai` |
+
+### SIWB Canister (Authentication)
+
+Sign-In With Bitcoin - handles authentication delegation.
+
+| Environment | Canister ID |
+|-------------|-------------|
+| All | `bcxqa-kqaaa-aaaak-qotba-cai` |
+
+### Voucher Canister
+
+Handles voucher code claiming and rewards.
+
+| Environment | Canister ID |
+|-------------|-------------|
+| Development | `7njii-eqaaa-aaaaj-a2gba-cai` |
+| Staging | `7kio4-jiaaa-aaaaj-a2gbq-cai` |
+
+### FastBTC Canister
+
+Handles BTC and ckBTC deposits and withdrawals.
+
+| Environment | Canister ID |
+|-------------|-------------|
+| All | `ztwhb-qiaaa-aaaaj-azw7a-cai` |
+
+### ckBTC Ledger
+
+ICRC-1 token ledger for ckBTC.
+
+| Environment | Canister ID |
+|-------------|-------------|
+| All | `mxzaz-hqaaa-aaaar-qaada-cai` |
+
+### ckBTC Minter
+
+Mints and burns ckBTC tokens.
+
+| Environment | Canister ID |
+|-------------|-------------|
+| All | `mqygn-kiaaa-aaaar-qaadq-cai` |
+
+### Volt
+
+Volt protocol integration for transfers and authorization.
+
+| Environment | Canister ID |
+|-------------|-------------|
+| All | `aclt4-uaaaa-aaaak-qb4zq-cai` |
+
+### Staking Canister
+
+Token staking with lock periods.
+
+| Environment | Canister ID |
+|-------------|-------------|
+| Development | `sfgyi-iyaaa-aaaam-qepyq-cai` |
+| Production | TBD |
+
+## API Endpoints
+
+| Environment | Base URL |
+|-------------|----------|
+| Development | `https://api.odin.fun/dev` |
+| Staging | `https://api.odin.fun/v1` |
+| Production | `https://api.odin.fun/v1` |
+
+## IC Host
+
+| Network | Host URL |
+|---------|----------|
+| Mainnet | `https://ic0.app` |
+| Local | `http://localhost:4943` |
+
+## Environment Detection
+
+The environment is determined by the hostname of the application:
+
+```typescript
+function getCurrentEnv(): "development" | "staging" | "production" {
+  const hostname = window.location.hostname;
+  if (hostname === "odin.fun") return "production";
+  if (hostname.includes("staging.odin.fun")) return "staging";
+  return "development";
+}
+```
+
+## Setup Example
+
+Complete configuration for initializing canister connections:
+
+```typescript
+import { Actor, HttpAgent } from "@dfinity/agent";
+import { idlFactory as OdinIDL } from "./odin.idl";
+import { idlFactory as SiwbIDL } from "./siwb.idl";
+
+// Configuration per environment
+const config = {
+  development: {
+    odinCanisterId: "w5cxm-6iaaa-aaaaj-az4jq-cai",
+    siwbCanisterId: "bcxqa-kqaaa-aaaak-qotba-cai",
+    fastbtcCanisterId: "ztwhb-qiaaa-aaaaj-azw7a-cai",
+    voucherCanisterId: "7njii-eqaaa-aaaaj-a2gba-cai",
+    apiUrl: "https://api.odin.fun/dev",
+    icHost: "https://ic0.app",
+  },
+  staging: {
+    odinCanisterId: "z2vm5-gaaaa-aaaaj-azw6q-cai",
+    siwbCanisterId: "bcxqa-kqaaa-aaaak-qotba-cai",
+    fastbtcCanisterId: "ztwhb-qiaaa-aaaaj-azw7a-cai",
+    voucherCanisterId: "7kio4-jiaaa-aaaaj-a2gbq-cai",
+    apiUrl: "https://api.odin.fun/v1",
+    icHost: "https://ic0.app",
+  },
+  production: {
+    odinCanisterId: "z2vm5-gaaaa-aaaaj-azw6q-cai",
+    siwbCanisterId: "bcxqa-kqaaa-aaaak-qotba-cai",
+    fastbtcCanisterId: "ztwhb-qiaaa-aaaaj-azw7a-cai",
+    voucherCanisterId: "7kio4-jiaaa-aaaaj-a2gbq-cai",
+    apiUrl: "https://api.odin.fun/v1",
+    icHost: "https://ic0.app",
+  },
+};
+
+// Create agent and actor
+const env = getCurrentEnv();
+const envConfig = config[env];
+
+const agent = new HttpAgent({
+  host: envConfig.icHost,
+  identity: authenticatedIdentity,
+});
+
+const odinActor = Actor.createActor(OdinIDL, {
+  agent,
+  canisterId: envConfig.odinCanisterId,
+});
+```
+
+## Canister Architecture
+
+```
+┌─────────────────────────────────────────────────────┐
+│                     User Wallet                      │
+│              (Bitcoin / NFID / LaserEyes)            │
+└────────────────────┬────────────────────────────────┘
+                     │
+        ┌────────────┼────────────────┐
+        ▼            ▼                ▼
+┌──────────────┐ ┌──────────┐ ┌──────────────┐
+│ SIWB Canister│ │ Odin API │ │ Odin Canister│
+│ (Auth)       │ │ (REST)   │ │ (Trading)    │
+└──────────────┘ └──────────┘ └──────┬───────┘
+                                     │
+                    ┌────────────────┼────────────────┐
+                    ▼                ▼                ▼
+            ┌──────────────┐ ┌──────────┐ ┌──────────────┐
+            │ FastBTC      │ │ Voucher  │ │ Staking      │
+            │ (Deposits)   │ │ (Codes)  │ │ (Lock/Earn)  │
+            └──────┬───────┘ └──────────┘ └──────────────┘
+                   │
+          ┌────────┼────────┐
+          ▼                 ▼
+   ┌──────────────┐ ┌──────────────┐
+   │ ckBTC Ledger │ │ ckBTC Minter │
+   │ (ICRC-1)     │ │              │
+   └──────────────┘ └──────────────┘
+```
+
+## Dependencies
+
+Required packages for canister integration:
+
+```bash
+npm install @dfinity/agent @dfinity/identity @dfinity/principal @dfinity/candid
+```

--- a/docs/canister/error-handling.mdx
+++ b/docs/canister/error-handling.mdx
@@ -1,0 +1,234 @@
+---
+title: "Error Handling"
+description: "Handle canister errors, delegation expiration, and common failure modes"
+---
+
+# Error Handling
+
+This guide covers error handling patterns for Odin canister interactions, including response parsing, delegation management, and recovery strategies.
+
+## Response Patterns
+
+The Odin canister uses two different response patterns depending on the method:
+
+### Pattern 1: `ok` / `err` (Odin Canister)
+
+Most Odin canister methods return lowercase variants:
+
+```typescript
+type Response = { ok: T } | { err: string }
+
+// Usage
+const result = await actor.token_trade(request);
+
+if ("ok" in result) {
+  // Success - process result.ok
+} else {
+  // Error - handle result.err
+  console.error("Trade failed:", result.err);
+}
+```
+
+### Pattern 2: `Ok` / `Err` (SIWB Canister)
+
+The SIWB canister returns capitalized variants:
+
+```typescript
+type Response = { Ok: T } | { Err: string }
+
+// Usage
+const result = await siwbActor.siwb_get_delegation(address, publicKey, expiration);
+
+if ("Ok" in result) {
+  // Success
+  const delegation = result.Ok;
+} else {
+  // Error
+  console.error("Delegation failed:", result.Err);
+}
+```
+
+### Pattern 3: Direct Return
+
+Some methods return values directly without wrapping:
+
+```typescript
+// getBalance returns bigint directly
+const balance = await actor.getBalance(address, tokenId);
+
+// user_claim returns bigint directly
+const claimed = await actor.user_claim();
+
+// getToken returns optional (empty array = not found)
+const token = await actor.getToken(tokenId);
+if (token.length === 0) {
+  console.log("Token not found");
+}
+```
+
+## Delegation Expiration
+
+Identity delegations expire after a set period. When a delegation expires, canister calls will fail. You must detect this and prompt the user to re-authenticate.
+
+### Detecting Expired Delegations
+
+```typescript
+function extractMessageFromError(error: unknown): string | null {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return null;
+  }
+}
+
+function isExpiredDelegation(error: unknown): boolean {
+  const message = extractMessageFromError(error);
+  if (!message) return false;
+  return message.includes("delegation has expired")
+    || message.includes("Invalid delegation");
+}
+```
+
+### Handling Expired Delegations
+
+```typescript
+async function safeCanisterCall<T>(
+  call: () => Promise<T>,
+  onExpired: () => void,
+): Promise<T> {
+  try {
+    return await call();
+  } catch (error) {
+    if (isExpiredDelegation(error)) {
+      onExpired(); // Trigger re-authentication
+      throw new Error("Session expired. Please reconnect your wallet.");
+    }
+    throw error;
+  }
+}
+
+// Usage
+const result = await safeCanisterCall(
+  () => actor.token_trade(request),
+  () => logout(),
+);
+```
+
+## Common Error Messages
+
+### Trading Errors
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| `"Insufficient balance"` | Not enough BTC or tokens | Check balance before trading |
+| `"Slippage exceeded"` | Price moved beyond tolerance | Increase slippage or retry |
+| `"Token not found"` | Invalid token ID | Verify token exists |
+| `"Amount too small"` | Trade below minimum | Increase trade amount |
+
+### Transfer Errors
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| `"Insufficient balance"` | Not enough tokens | Check balance first |
+| `"Invalid recipient"` | Bad address/principal | Validate address format |
+| `"Transfer blocked"` | Restrictions on token | Check token transfer rules |
+
+### Withdrawal Errors
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| `"Minimum amount"` | Below withdrawal minimum | Increase amount |
+| `"Invalid address"` | Bad destination address | Verify address for the protocol |
+| `"Protocol not supported"` | Wrong protocol for token | Use correct protocol |
+
+### Authentication Errors
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| `"delegation has expired"` | Session expired | Re-authenticate |
+| `"No identity"` | Not logged in | Connect wallet first |
+| `"Canister not initialized"` | Agent not ready | Wait for identity |
+
+## Error Handling Best Practices
+
+### 1. Always Check Response Variants
+
+```typescript
+// Never assume success
+const result = await actor.token_trade(request);
+
+if ("err" in result) {
+  // Handle error before proceeding
+  throw new Error(result.err);
+}
+
+// Safe to proceed with result.ok
+```
+
+### 2. Wrap Calls with Try/Catch
+
+Canister calls can throw network errors even before returning a response:
+
+```typescript
+try {
+  const result = await actor.token_trade(request);
+
+  if ("err" in result) {
+    // Canister returned an error
+    handleCanisterError(result.err);
+  } else {
+    // Success
+    handleSuccess(result.ok);
+  }
+} catch (error) {
+  // Network error, timeout, or delegation expiration
+  handleNetworkError(error);
+}
+```
+
+### 3. Validate Amounts Before Sending
+
+```typescript
+function validateAmount(amount: bigint): void {
+  if (amount <= 0n) {
+    throw new Error("Amount must be positive");
+  }
+}
+
+// Pre-validate before canister call
+validateAmount(tradeAmount);
+const result = await actor.token_trade(request);
+```
+
+### 4. Handle BigInt Serialization
+
+When logging or transmitting canister responses, BigInt values need special handling:
+
+```typescript
+function sanitizeForLogging(obj: unknown): unknown {
+  if (typeof obj === "bigint") {
+    return obj.toString();
+  }
+  if (obj instanceof Uint8Array) {
+    return Array.from(obj);
+  }
+  if (Array.isArray(obj)) {
+    return obj.map(sanitizeForLogging);
+  }
+  if (obj && typeof obj === "object") {
+    return Object.fromEntries(
+      Object.entries(obj).map(([k, v]) => [k, sanitizeForLogging(v)])
+    );
+  }
+  return obj;
+}
+
+// Usage with error tracking
+console.log(JSON.stringify(sanitizeForLogging(response)));
+```

--- a/docs/canister/get-balance.mdx
+++ b/docs/canister/get-balance.mdx
@@ -1,0 +1,87 @@
+---
+title: "getBalance"
+description: "Query a user's token balance"
+---
+
+# getBalance
+
+Query the balance of a specific token for a given user. This is a query method that doesn't modify state.
+
+## Method Signature
+
+```typescript
+getBalance: ActorMethod<[string, TokenID], TokenAmount>
+```
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `address` | `string` | Yes | The user's address or principal |
+| `tokenid` | `string` | Yes | The token identifier (e.g., `"btc"`, `"2kl9"`) |
+
+## Response
+
+Returns a `TokenAmount` (bigint) representing the user's balance in the token's smallest unit.
+
+```typescript
+type TokenAmount = bigint
+```
+
+## Example Usage
+
+### Check BTC Balance
+```typescript
+const balance = await actor.getBalance(userAddress, "btc");
+console.log(`BTC balance: ${balance} (${Number(balance) / 1e8} BTC)`);
+```
+
+### Check Token Balance
+```typescript
+const tokenId = "2kl9";
+const balance = await actor.getBalance(userAddress, tokenId);
+console.log(`Token balance: ${balance}`);
+```
+
+### Check Multiple Token Balances
+```typescript
+const tokenIds = ["btc", "2kl9", "3ab8"];
+
+const balances = await Promise.all(
+  tokenIds.map(async (id) => ({
+    tokenId: id,
+    balance: await actor.getBalance(userAddress, id),
+  }))
+);
+
+balances.forEach(({ tokenId, balance }) => {
+  console.log(`${tokenId}: ${balance}`);
+});
+```
+
+## Amount Conversion
+
+Token amounts are returned in the smallest unit. To convert to a human-readable format:
+
+```typescript
+const rawBalance = await actor.getBalance(userAddress, tokenId);
+
+// For BTC (8 decimals):
+const btcAmount = Number(rawBalance) / 1e8;
+
+// For tokens with custom divisibility/decimals:
+// Use the token's divisibility + decimals from getToken()
+const tokenInfo = await actor.getToken(tokenId);
+if (tokenInfo.length > 0) {
+  // Raw amount includes both divisibility and decimal precision
+  const displayAmount = Number(rawBalance) / (10 ** 8); // Adjust based on token
+}
+```
+
+## Query Method
+
+This is a **query method**, meaning:
+- It doesn't modify canister state
+- It's faster and cheaper to call
+- Results are not certified (for certified data, use update calls)
+- Can be called without authentication

--- a/docs/canister/get-token.mdx
+++ b/docs/canister/get-token.mdx
@@ -1,0 +1,144 @@
+---
+title: "getToken"
+description: "Query token information and metadata"
+---
+
+# getToken
+
+Retrieve detailed information about a specific token, including its supply, pool state, bonding curve, and rune data. This is a query method that doesn't modify state.
+
+## Method Signature
+
+```typescript
+getToken: ActorMethod<[TokenID], [] | [Token]>
+```
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `tokenid` | `string` | Yes | The token identifier |
+
+## Response
+
+Returns an optional `Token` object. An empty array `[]` means the token was not found.
+
+### Token
+```typescript
+interface Token {
+  creator: Principal;           // Token creator's principal
+  lp_supply: TokenAmount;       // Total LP token supply
+  bonded_btc: TokenAmount;      // BTC in bonding curve
+  pool: LiquidityPool;          // AMM pool state
+  rune: [] | [Rune];            // Optional rune data
+  bonding_threshold_reward: TokenAmount;  // Reward at bonding
+  supply: TokenAmount;          // Current circulating supply
+  icrc_canister: [] | [Principal];       // Optional ICRC canister
+  max_supply: TokenAmount;      // Maximum token supply
+  bonding_curve: [] | [BondingCurveSettings];  // Bonding curve params
+  bonding_threshold: TokenAmount;       // BTC needed to bond
+  bonding_threshold_fee: TokenAmount;   // Fee at bonding
+}
+```
+
+### LiquidityPool
+```typescript
+interface LiquidityPool {
+  locked: LiquiditySwap;   // Locked liquidity amounts
+  current: LiquiditySwap;  // Current pool amounts
+}
+
+interface LiquiditySwap {
+  btc: TokenAmount;    // BTC in pool
+  token: TokenAmount;  // Tokens in pool
+}
+```
+
+### Rune
+```typescript
+interface Rune {
+  id: string;       // Bitcoin rune ID
+  ticker: string;   // Rune ticker
+  name: string;     // Rune name
+}
+```
+
+### BondingCurveSettings
+```typescript
+interface BondingCurveSettings {
+  a: number;     // Curve parameter a
+  b: number;     // Curve parameter b
+  c: number;     // Curve parameter c
+  name: string;  // Curve name
+}
+```
+
+## Example Usage
+
+### Basic Token Lookup
+```typescript
+const tokenData = await actor.getToken("2kl9");
+
+if (tokenData.length > 0) {
+  const token = tokenData[0];
+  console.log("Creator:", token.creator.toText());
+  console.log("Supply:", token.supply);
+  console.log("Max Supply:", token.max_supply);
+} else {
+  console.log("Token not found");
+}
+```
+
+### Check if Token is Bonded
+```typescript
+const tokenData = await actor.getToken("2kl9");
+
+if (tokenData.length > 0) {
+  const token = tokenData[0];
+  const isBonded = token.bonded_btc >= token.bonding_threshold;
+  console.log(`Token is ${isBonded ? "bonded (AMM)" : "unbonded (bonding curve)"}`);
+}
+```
+
+### Inspect Pool State
+```typescript
+const tokenData = await actor.getToken("2kl9");
+
+if (tokenData.length > 0) {
+  const token = tokenData[0];
+  const pool = token.pool;
+
+  console.log("Current Pool:");
+  console.log(`  BTC: ${pool.current.btc}`);
+  console.log(`  Token: ${pool.current.token}`);
+
+  console.log("Locked Liquidity:");
+  console.log(`  BTC: ${pool.locked.btc}`);
+  console.log(`  Token: ${pool.locked.token}`);
+
+  console.log(`LP Supply: ${token.lp_supply}`);
+}
+```
+
+### Check Rune Association
+```typescript
+const tokenData = await actor.getToken("2kl9");
+
+if (tokenData.length > 0) {
+  const token = tokenData[0];
+  if (token.rune.length > 0) {
+    const rune = token.rune[0];
+    console.log(`Rune: ${rune.name} (${rune.ticker}) - ID: ${rune.id}`);
+  } else {
+    console.log("No rune associated with this token");
+  }
+}
+```
+
+## Query Method
+
+This is a **query method**, meaning:
+- It doesn't modify canister state
+- It's faster and cheaper to call
+- Results are not certified (for certified data, use update calls)
+- Can be called without authentication

--- a/docs/canister/overview.mdx
+++ b/docs/canister/overview.mdx
@@ -5,25 +5,46 @@ description: "Overview of the Odin smart contract (canister) methods and functio
 
 # Odin Canister
 
-The Odin canister is a smart contract deployed on the Internet Computer that provides core functionality for token trading, transfers, operations tracking, and user claims.
+The Odin canister is a smart contract deployed on the Internet Computer that provides core functionality for token trading, creation, liquidity management, transfers, operations tracking, and user claims.
 
 ## Available Methods
 
 This documentation covers the following canister methods:
 
+### Token Creation
+- **[token_mint](/canister/token-mint)** - Create a new token with metadata, optional prebuy, and discount code
+
 ### Trading
-- **token_trade** - Execute buy/sell trades for tokens
+- **[token_trade](/canister/token-trade)** - Execute buy/sell trades for tokens
+- **[token_swap](/canister/token-swap)** - Swap directly between two tokens
+
+### Liquidity
+- **[token_liquidity](/canister/token-liquidity)** - Add or remove liquidity from AMM pools
+
+### Deposits & Withdrawals
+- **[token_deposit](/canister/token-deposit)** - Deposit BTC to the platform
+- **[token_withdraw](/canister/token-withdraw)** - Withdraw tokens to external addresses
 
 ### Transfers
-- **token_transfer** - Transfer tokens between users
-- **token_withdraw** - Withdraw tokens to external addresses
+- **[token_transfer](/canister/token-transfer)** - Transfer tokens between users
 
-### Operations
-- **getOperations** - Retrieve multiple operations with pagination
-- **getOperation** - Retrieve a specific operation by ID
+### Rune Listing
+- **[token_list](/canister/token-list)** - List a Bitcoin rune on the platform
+
+### Query Methods
+- **[getBalance](/canister/get-balance)** - Query a user's token balance
+- **[getToken](/canister/get-token)** - Query token information and metadata
+- **[getOperations](/canister/get-operations)** - Retrieve multiple operations with pagination
+- **[getOperation](/canister/get-operation)** - Retrieve a specific operation by ID
 
 ### User
-- **user_claim** - Claim tokens for the authenticated user
+- **[user_claim](/canister/user-claim)** - Claim tokens for the authenticated user
+- **[voucher_claim](/canister/voucher-claim)** - Claim tokens using a voucher code
+- **[access_grant](/canister/access-grant)** - Grant platform access with an access code
+
+### Guides
+- **[Error Handling](/canister/error-handling)** - Handle errors, delegation expiration, and recovery
+- **[Configuration Reference](/canister/configuration)** - All canister IDs, API URLs, and environment setup
 
 ## Method Types
 
@@ -31,10 +52,12 @@ All canister methods return results in a standardized format:
 - **Success**: `{ ok: result }` where result contains the expected data
 - **Error**: `{ err: string }` where string contains the error message
 
+Query methods (`getBalance`, `getToken`, `getOperations`, `getOperation`) return values directly without wrapping.
+
 ## Common Types
 
 ### TokenID
-A string identifier for tokens.
+A string identifier for tokens. Use `"btc"` for the primary BTC token, or token-specific IDs like `"2kl9"`.
 
 ### TokenAmount
 A bigint representing token amounts (typically in the smallest unit).
@@ -45,4 +68,14 @@ A bigint representing token amounts (typically in the smallest unit).
 ```
 
 ### Principal
-An Internet Computer principal identifier representing users or canisters. 
+An Internet Computer principal identifier representing users or canisters.
+
+### Canister IDs
+
+| Environment | Canister ID |
+|-------------|-------------|
+| Development | `w5cxm-6iaaa-aaaaj-az4jq-cai` |
+| Staging | `z2vm5-gaaaa-aaaaj-azw6q-cai` |
+| Production | `z2vm5-gaaaa-aaaaj-azw6q-cai` |
+
+See the [Configuration Reference](/canister/configuration) for all canister IDs and environment setup.

--- a/docs/canister/token-deposit.mdx
+++ b/docs/canister/token-deposit.mdx
@@ -1,0 +1,74 @@
+---
+title: "token_deposit"
+description: "Deposit BTC to the Odin platform"
+---
+
+# token_deposit
+
+Deposit BTC into the Odin platform. This credits the deposited amount to the caller's on-platform balance.
+
+## Method Signature
+
+```typescript
+token_deposit: ActorMethod<[TokenID, TokenAmount], TokenAmount>
+```
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `tokenid` | `string` | Yes | The token ID to deposit (typically `"btc"`) |
+| `amount` | `TokenAmount` | Yes | Amount to deposit (bigint, in smallest unit) |
+
+## Response
+
+Returns a `TokenAmount` (bigint) representing the new balance after the deposit.
+
+```typescript
+type TokenAmount = bigint
+```
+
+## Example Usage
+
+### Basic BTC Deposit
+```typescript
+const tokenId = "btc";
+const amount = 10_000_000n; // 0.1 BTC in satoshis
+
+try {
+  const newBalance = await actor.token_deposit(tokenId, amount);
+  console.log(`Deposit successful. New balance: ${newBalance}`);
+} catch (error) {
+  console.error("Deposit failed:", error);
+}
+```
+
+### Deposit with Balance Verification
+```typescript
+// Check balance before
+const balanceBefore = await actor.getBalance(userAddress, "btc");
+
+// Make deposit
+const amount = 5_000_000n;
+const newBalance = await actor.token_deposit("btc", amount);
+
+console.log(`Balance before: ${balanceBefore}`);
+console.log(`Balance after:  ${newBalance}`);
+```
+
+## Deposit Flow
+
+For production deposits, the typical flow involves multiple steps:
+
+1. **Get a deposit address** from the FastBTC canister for your principal
+2. **Send BTC** to the generated deposit address from your external wallet
+3. **Wait for confirmation** - the platform processes incoming UTXOs automatically
+4. **Funds appear** in your on-platform balance
+
+The `token_deposit` method is used for direct on-chain deposits where BTC is already available to the canister.
+
+## Common Errors
+
+- **Insufficient funds**: The specified amount exceeds available funds
+- **Invalid token**: The token ID is not recognized
+- **Canister not initialized**: Identity or agent not properly set up

--- a/docs/canister/token-liquidity.mdx
+++ b/docs/canister/token-liquidity.mdx
@@ -1,0 +1,110 @@
+---
+title: "token_liquidity"
+description: "Add or remove liquidity for tokens"
+---
+
+# token_liquidity
+
+Add or remove liquidity for a token's AMM pool. Liquidity can only be managed for bonded tokens (tokens that have reached their bonding threshold).
+
+## Method Signature
+
+```typescript
+token_liquidity: ActorMethod<[LiquidityRequest], LiquidityResponse>
+```
+
+## Parameters
+
+### LiquidityRequest
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `tokenid` | `string` | Yes | The token identifier |
+| `typeof` | `LiquidityType` | Yes | Operation type: add or remove |
+| `amount` | `TokenAmount` | Yes | BTC amount (for add) or LP token amount (for remove) |
+
+### LiquidityType
+```typescript
+type LiquidityType = { add: null } | { remove: null }
+```
+
+- **add**: Provide BTC liquidity to the token's AMM pool
+- **remove**: Remove LP tokens and receive back BTC and tokens
+
+## Response
+
+### LiquidityResponse
+```typescript
+type LiquidityResponse = { ok: null } | { err: string }
+```
+
+- **Success**: `{ ok: null }` - Liquidity operation completed successfully
+- **Error**: `{ err: string }` - Error message describing what went wrong
+
+## Example Usage
+
+### Add Liquidity
+```typescript
+const addRequest = {
+  tokenid: "2kl9",
+  typeof: { add: null },
+  amount: 5_000_000n, // BTC amount in smallest unit
+};
+
+const result = await actor.token_liquidity(addRequest);
+
+if ("ok" in result) {
+  console.log("Liquidity added successfully!");
+} else {
+  console.error("Failed to add liquidity:", result.err);
+}
+```
+
+### Remove Liquidity
+```typescript
+const removeRequest = {
+  tokenid: "2kl9",
+  typeof: { remove: null },
+  amount: 1_000_000n, // LP token amount to remove
+};
+
+const result = await actor.token_liquidity(removeRequest);
+
+if ("ok" in result) {
+  console.log("Liquidity removed successfully!");
+} else {
+  console.error("Failed to remove liquidity:", result.err);
+}
+```
+
+### Check Liquidity Before Adding
+
+Use the `getToken` query method to inspect the pool state before providing liquidity:
+
+```typescript
+const tokenData = await actor.getToken("2kl9");
+
+if (tokenData.length > 0) {
+  const token = tokenData[0];
+  console.log("Pool BTC:", token.pool.current.btc);
+  console.log("Pool Token:", token.pool.current.token);
+  console.log("LP Supply:", token.lp_supply);
+}
+```
+
+## Key Concepts
+
+### Bonded vs Unbonded Tokens
+- **Unbonded tokens** trade on a bonding curve and do not support liquidity operations
+- **Bonded tokens** have reached their bonding threshold and trade on an AMM pool
+- Liquidity can only be added to or removed from bonded tokens
+
+### LP Tokens
+When you add liquidity, you receive LP (Liquidity Provider) tokens representing your share of the pool. When removing liquidity, you burn LP tokens to receive back your proportional share of BTC and tokens.
+
+## Common Errors
+
+- **Insufficient balance**: Not enough BTC (for add) or LP tokens (for remove)
+- **Token not bonded**: Token has not reached the bonding threshold yet
+- **Token not found**: Specified token ID doesn't exist
+- **Invalid amount**: Amount is zero or exceeds available balance

--- a/docs/canister/token-list.mdx
+++ b/docs/canister/token-list.mdx
@@ -1,0 +1,73 @@
+---
+title: "token_list"
+description: "List a Bitcoin rune on the Odin platform"
+---
+
+# token_list
+
+List an existing Bitcoin rune on the Odin platform, making it available for trading. A listing fee is charged in BTC.
+
+## Method Signature
+
+```typescript
+token_list: ActorMethod<[ListRequest], ListResponse>
+```
+
+## Parameters
+
+### ListRequest
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `rune_id` | `string` | Yes | The Bitcoin rune identifier to list |
+
+## Response
+
+### ListResponse
+```typescript
+type ListResponse = { ok: TokenAmount } | { err: string }
+```
+
+- **Success**: `{ ok: TokenAmount }` - Returns the listing fee charged (bigint in BTC smallest unit)
+- **Error**: `{ err: string }` - Error message describing what went wrong
+
+## Example Usage
+
+### List a Rune
+```typescript
+const listRequest = {
+  rune_id: "845623:45", // Rune ID format: block:tx_index
+};
+
+const result = await actor.token_list(listRequest);
+
+if ("ok" in result) {
+  const feeCharged = result.ok;
+  console.log(`Rune listed successfully! Fee charged: ${feeCharged}`);
+} else {
+  console.error("Listing failed:", result.err);
+}
+```
+
+### List with Fee Verification
+```typescript
+// Check BTC balance before listing
+const balance = await actor.getBalance(userAddress, "btc");
+console.log(`Current BTC balance: ${balance}`);
+
+const result = await actor.token_list({ rune_id: "845623:45" });
+
+if ("ok" in result) {
+  const fee = result.ok;
+  console.log(`Listed! Fee: ${fee} (${Number(fee) / 1e8} BTC)`);
+} else {
+  console.error("Listing failed:", result.err);
+}
+```
+
+## Common Errors
+
+- **Insufficient balance**: Not enough BTC to cover the listing fee
+- **Rune not found**: The specified rune ID doesn't exist on Bitcoin
+- **Already listed**: The rune is already listed on the platform
+- **Invalid rune ID**: The rune ID format is incorrect

--- a/docs/canister/token-mint.mdx
+++ b/docs/canister/token-mint.mdx
@@ -1,0 +1,165 @@
+---
+title: "token_mint"
+description: "Create a new token on the Odin platform"
+---
+
+# token_mint
+
+Create a new token on the Odin platform with metadata, optional initial purchase (prebuy), and optional discount code.
+
+## Method Signature
+
+```typescript
+token_mint: ActorMethod<[MintRequest], MintResponse>
+```
+
+## Parameters
+
+### MintRequest
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `metadata` | `Metadata` | Yes | Token metadata (name, ticker, description, image, socials) |
+| `prebuy_amount` | `[] \| [TokenAmount]` | No | Optional BTC amount for initial purchase at creation |
+| `code` | `[] \| [string]` | No | Optional discount code for reduced fees |
+
+### Metadata
+
+Metadata is an array of key-value pairs describing the token:
+
+```typescript
+type Metadata = Array<[string, MetadataValue]>;
+
+type MetadataValue =
+  | { text: string }
+  | { nat: bigint }
+  | { int: bigint }
+  | { bool: boolean }
+  | { principal: Principal }
+  | { blob: Uint8Array }
+  | { hex: string }
+  | { nat8: number };
+```
+
+### Required Metadata Fields
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `name` | `{ text: string }` | Token display name |
+| `ticker` | `{ text: string }` | Token ticker symbol |
+| `description` | `{ text: string }` | Token description |
+| `image` | `{ text: string }` | Token image URL (upload via API first) |
+
+### Optional Metadata Fields
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `twitter` | `{ text: string }` | Twitter/X profile URL |
+| `telegram` | `{ text: string }` | Telegram group URL |
+| `website` | `{ text: string }` | Project website URL |
+
+## Response
+
+### MintResponse
+```typescript
+type MintResponse = { ok: null } | { err: string }
+```
+
+- **Success**: `{ ok: null }` - Token created successfully
+- **Error**: `{ err: string }` - Error message describing what went wrong
+
+## Example Usage
+
+### Basic Token Creation
+```typescript
+const mintRequest = {
+  metadata: [
+    ["name", { text: "My Token" }],
+    ["ticker", { text: "MYTKN" }],
+    ["description", { text: "A community-driven token on Odin" }],
+    ["image", { text: "https://your-uploaded-image-url.com/image.png" }],
+    ["twitter", { text: "https://x.com/mytoken" }],
+    ["telegram", { text: "https://t.me/mytoken" }],
+    ["website", { text: "https://mytoken.com" }],
+  ],
+  prebuy_amount: [],
+  code: [],
+};
+
+const result = await actor.token_mint(mintRequest);
+
+if ("ok" in result) {
+  console.log("Token created successfully!");
+} else {
+  console.error("Token creation failed:", result.err);
+}
+```
+
+### Token Creation with Prebuy
+
+Buy tokens at creation time to be the first holder:
+
+```typescript
+const prebuyBtcAmount = 10_000_000n; // 0.1 BTC in satoshis
+
+const mintRequest = {
+  metadata: [
+    ["name", { text: "My Token" }],
+    ["ticker", { text: "MYTKN" }],
+    ["description", { text: "A community-driven token on Odin" }],
+    ["image", { text: "https://your-uploaded-image-url.com/image.png" }],
+    ["twitter", { text: "" }],
+    ["telegram", { text: "" }],
+    ["website", { text: "" }],
+  ],
+  prebuy_amount: [prebuyBtcAmount],
+  code: [],
+};
+
+const result = await actor.token_mint(mintRequest);
+```
+
+### Token Creation with Discount Code
+
+```typescript
+const mintRequest = {
+  metadata: [
+    ["name", { text: "My Token" }],
+    ["ticker", { text: "MYTKN" }],
+    ["description", { text: "A community-driven token on Odin" }],
+    ["image", { text: "https://your-uploaded-image-url.com/image.png" }],
+    ["twitter", { text: "" }],
+    ["telegram", { text: "" }],
+    ["website", { text: "" }],
+  ],
+  prebuy_amount: [],
+  code: ["YOUR_DISCOUNT_CODE"],
+};
+
+const result = await actor.token_mint(mintRequest);
+```
+
+## Image Upload
+
+Before creating a token, upload the image using the REST API:
+
+```typescript
+const formData = new FormData();
+formData.append("file", imageFile);
+
+const uploadResponse = await fetch("https://api.odin.fun/v1/upload", {
+  method: "POST",
+  headers: { Authorization: `Bearer ${jwtToken}` },
+  body: formData,
+});
+
+const { url } = await uploadResponse.json();
+// Use `url` in the image metadata field
+```
+
+## Common Errors
+
+- **Insufficient balance**: Not enough BTC to cover creation fee or prebuy amount
+- **Invalid metadata**: Missing required fields (name, ticker, description, image)
+- **Ticker taken**: The ticker symbol is already in use
+- **Invalid discount code**: The provided code is expired or invalid

--- a/docs/canister/token-swap.mdx
+++ b/docs/canister/token-swap.mdx
@@ -1,0 +1,104 @@
+---
+title: "token_swap"
+description: "Swap directly between two tokens"
+---
+
+# token_swap
+
+Swap tokens directly from one token to another without manually selling and rebuying. This executes an atomic swap through the platform.
+
+## Method Signature
+
+```typescript
+token_swap: ActorMethod<[SwapRequest], SwapResponse>
+```
+
+## Parameters
+
+### SwapRequest
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `tokenid_from` | `string` | Yes | The token ID to swap from |
+| `tokenid_to` | `string` | Yes | The token ID to swap to |
+| `amount_from` | `TokenAmount` | Yes | Amount of the source token to swap (bigint) |
+| `settings` | `[] \| [TradeSettings]` | No | Optional trade settings including slippage |
+
+### TradeSettings (Optional)
+```typescript
+interface TradeSettings {
+  slippage: [] | [[TokenAmount, bigint]]  // [expectedPrice, tolerance]
+}
+```
+
+Slippage tolerance is expressed as:
+- First value: expected price
+- Second value: allowed deviation as `Math.floor(percentage * 100000)` (e.g., 1% = `1000`)
+
+## Response
+
+### SwapResponse
+```typescript
+type SwapResponse = { ok: null } | { err: string }
+```
+
+- **Success**: `{ ok: null }` - Swap executed successfully
+- **Error**: `{ err: string }` - Error message describing what went wrong
+
+## Example Usage
+
+### Basic Token-to-Token Swap
+```typescript
+const swapRequest = {
+  tokenid_from: "2kl9",   // Source token
+  tokenid_to: "3ab8",     // Destination token
+  amount_from: 500_000_000_000n, // Amount of source token
+  settings: [],
+};
+
+const result = await actor.token_swap(swapRequest);
+
+if ("ok" in result) {
+  console.log("Swap completed successfully!");
+} else {
+  console.error("Swap failed:", result.err);
+}
+```
+
+### Swap with Slippage Protection
+```typescript
+const expectedPrice = 150000n; // Expected price ratio
+const slippageTolerance = 0.02; // 2%
+
+const swapRequest = {
+  tokenid_from: "2kl9",
+  tokenid_to: "3ab8",
+  amount_from: 500_000_000_000n,
+  settings: [{
+    slippage: [[expectedPrice, BigInt(Math.floor(slippageTolerance * 100000))]],
+  }],
+};
+
+const result = await actor.token_swap(swapRequest);
+
+if ("ok" in result) {
+  console.log("Swap completed successfully!");
+} else {
+  console.error("Swap failed:", result.err);
+}
+```
+
+## How Swaps Work
+
+A token swap internally:
+1. Sells the source token (`tokenid_from`) for BTC
+2. Uses the BTC to buy the destination token (`tokenid_to`)
+
+This happens atomically in a single canister call, so either both operations succeed or neither does.
+
+## Common Errors
+
+- **Insufficient balance**: Not enough of the source token
+- **Token not found**: One of the token IDs doesn't exist
+- **Slippage exceeded**: Price moved beyond the allowed tolerance
+- **Invalid amount**: Amount is zero or invalid

--- a/docs/canister/voucher-claim.mdx
+++ b/docs/canister/voucher-claim.mdx
@@ -1,0 +1,78 @@
+---
+title: "voucher_claim"
+description: "Claim tokens using a voucher code"
+---
+
+# voucher_claim
+
+Claim tokens using a voucher code. Vouchers are distributed for promotions, referrals, and community rewards.
+
+<Note>
+This method calls the **Voucher canister**, which is separate from the main Odin canister. See the [Configuration Reference](/canister/configuration) for canister IDs.
+</Note>
+
+## Method Signature
+
+```typescript
+voucher_claim: ActorMethod<[string], [] | [TokenAmount]>
+```
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `code` | `string` | Yes | The voucher code to claim |
+
+## Response
+
+Returns an optional `TokenAmount`:
+- `[TokenAmount]` - Amount of tokens claimed (bigint)
+- `[]` - Voucher not found or already claimed
+
+## Example Usage
+
+### Basic Voucher Claim
+```typescript
+try {
+  const result = await actor.voucher_claim("VOUCHER-CODE-123");
+
+  if (result.length > 0) {
+    const claimedAmount = result[0];
+    console.log(`Claimed ${claimedAmount} tokens!`);
+  } else {
+    console.log("Voucher not found or already claimed");
+  }
+} catch (error) {
+  console.error("Failed to claim voucher:", error);
+}
+```
+
+### Using the Voucher Canister Directly
+
+If integrating directly with the Voucher canister (not through the Odin wrapper):
+
+```typescript
+import { Actor, HttpAgent } from "@dfinity/agent";
+import { idlFactory } from "./voucher.idl";
+
+const agent = new HttpAgent({ host: "https://ic0.app", identity });
+const voucherActor = Actor.createActor(idlFactory, {
+  agent,
+  canisterId: "7njii-eqaaa-aaaaj-a2gba-cai", // Development
+});
+
+const result = await voucherActor.claim_voucher("VOUCHER-CODE-123");
+
+if ("ok" in result) {
+  console.log(`Claimed: ${result.ok}`);
+} else if ("err" in result) {
+  console.error(`Error: ${result.err}`);
+}
+```
+
+## Common Errors
+
+- **Invalid code**: The voucher code doesn't exist
+- **Already claimed**: The voucher has already been used
+- **Expired**: The voucher code has expired
+- **Not authenticated**: User must be logged in to claim vouchers

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -64,25 +64,53 @@
         {
           "group": "Overview",
           "pages": [
-            "canister/overview"
+            "canister/overview",
+            "canister/configuration"
+          ]
+        },
+        {
+          "group": "Token Creation",
+          "pages": [
+            "canister/token-mint"
           ]
         },
         {
           "group": "Trading",
           "pages": [
-            "canister/token-trade"
+            "canister/token-trade",
+            "canister/token-swap"
+          ]
+        },
+        {
+          "group": "Liquidity",
+          "pages": [
+            "canister/token-liquidity"
+          ]
+        },
+        {
+          "group": "Deposits & Withdrawals",
+          "pages": [
+            "canister/token-deposit",
+            "canister/token-withdraw"
           ]
         },
         {
           "group": "Transfers",
           "pages": [
-            "canister/token-transfer",
-            "canister/token-withdraw"
+            "canister/token-transfer"
           ]
         },
         {
-          "group": "Operations",
+          "group": "Rune Listing",
           "pages": [
+            "canister/token-list"
+          ]
+        },
+        {
+          "group": "Query Methods",
+          "pages": [
+            "canister/get-balance",
+            "canister/get-token",
             "canister/get-operations",
             "canister/get-operation"
           ]
@@ -90,7 +118,15 @@
         {
           "group": "User",
           "pages": [
-            "canister/user-claim"
+            "canister/user-claim",
+            "canister/voucher-claim",
+            "canister/access-grant"
+          ]
+        },
+        {
+          "group": "Guides",
+          "pages": [
+            "canister/error-handling"
           ]
         }
       ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -94,6 +94,44 @@
           ]
         }
       ]
+    },
+    {
+      "tab": "Staking",
+      "groups": [
+        {
+          "group": "Overview",
+          "pages": [
+            "staking/overview"
+          ]
+        },
+        {
+          "group": "Deposits & Withdrawals",
+          "pages": [
+            "staking/stake-deposit",
+            "staking/stake-withdraw"
+          ]
+        },
+        {
+          "group": "Staking Operations",
+          "pages": [
+            "staking/stake-lock-tokens",
+            "staking/stake-unlock"
+          ]
+        },
+        {
+          "group": "Position Management",
+          "pages": [
+            "staking/stake-increase-position",
+            "staking/stake-increase-duration"
+          ]
+        },
+        {
+          "group": "Query Methods",
+          "pages": [
+            "staking/queries"
+          ]
+        }
+      ]
     }
   ],
    

--- a/docs/staking/overview.mdx
+++ b/docs/staking/overview.mdx
@@ -5,6 +5,10 @@ description: "Overview of the Odin staking canister for locking tokens"
 
 # Staking Canister
 
+<Warning>
+**Under Development**: The staking canister is currently under active development and is not yet available in production. The canister IDs, method signatures, and behavior documented here may change before the final release. Use the development environment for testing only.
+</Warning>
+
 The Odin staking canister is a smart contract deployed on the Internet Computer that enables users to lock tokens for specified durations.
 
 <Info>

--- a/docs/staking/overview.mdx
+++ b/docs/staking/overview.mdx
@@ -1,0 +1,152 @@
+---
+title: "Staking Canister Overview"
+description: "Overview of the Odin staking canister for locking tokens"
+---
+
+# Staking Canister
+
+The Odin staking canister is a smart contract deployed on the Internet Computer that enables users to lock tokens for specified durations.
+
+<Info>
+**Lite Mode Documentation**: This documentation covers the basic staking functionality without reward pools. Users can lock tokens for specified durations, but no rewards are distributed. Reward pool features may be added in future versions.
+</Info>
+
+## Canister IDs
+
+### Development
+```
+sfgyi-iyaaa-aaaam-qepyq-cai
+```
+
+### Production
+```
+TBD (to be set after mainnet deployment)
+```
+
+## Architecture
+
+The staking canister integrates with the ODIN ledger to manage token deposits, withdrawals, and staking positions:
+
+```
+ODIN Ledger ←→ Staking Canister ←→ User
+    │              │                  │
+    │  Transfer    │  Lock/Unlock     │  Frontend
+    │  Approve     │  Query Balance   │  Queries
+```
+
+### Token Lifecycle
+
+1. **Deposit**: Tokens move from ODIN ledger to staking canister (available balance)
+2. **Lock**: Tokens move from available balance to staking position (locked)
+3. **Unlock**: Tokens move from staking position back to available balance (after expiry)
+4. **Withdraw**: Tokens move from available balance back to ODIN ledger
+
+## Available Methods
+
+This documentation covers the following canister methods:
+
+### Deposits & Withdrawals
+- **stake_deposit** - Deposit tokens from ODIN ledger to staking canister
+- **stake_withdraw** - Withdraw tokens from staking canister to ODIN ledger
+
+### Staking Operations
+- **stake_lock_tokens** - Create a new staking position with locked tokens
+- **stake_unlock** - Unlock an expired staking position
+
+### Position Management
+- **stake_increase_position** - Add more tokens to an existing position
+- **stake_increase_duration** - Extend the lock duration of an existing position
+
+### Query Methods
+- **stake_get_available_balance** - Get unlocked token balance
+- **stake_get_all_available_balances** - Get all unlocked balances
+- **stake_get_position** - Get a specific staking position
+- **stake_get_all_positions** - Get all staking positions
+
+<Info>
+In production, query methods should use the indexer/API for better performance. See [Query Methods](/staking/queries) for details.
+</Info>
+
+## Method Types
+
+**Update methods** (deposit, withdraw, lock, unlock, etc.) return results in a standardized format:
+- **Success**: `{ Ok: value }` where value contains the expected data
+- **Error**: `{ Err: string }` where string contains the error message
+
+**Query methods** (stake_get_*) return raw values directly without variant wrapping:
+- `stake_get_available_balance` returns `bigint`
+- `stake_get_position` returns `StakingPosition | undefined`
+- `stake_get_all_*` methods return arrays
+
+## Common Types
+
+### TokenID
+A string identifier for tokens using ODIN's token pointer format.
+
+**Valid formats:**
+- `"btc"` - Primary token (special case)
+- 4-12 character strings using base-34 encoding: `j 2 h 5 n 7 m 4 f 8 q 9 a b d e g k l p r s t u v w x y z 1 3 c 6 i`
+
+**Examples:**
+```typescript
+const tokenId = "btc";   // Primary token ✓
+const tokenId = "test";  // Valid (4 chars) ✓
+const tokenId = "usdc";  // Valid (4 chars) ✓
+```
+
+### TokenAmount
+A bigint representing token amounts.
+
+```typescript
+const amount = 1_000_000n;
+const amount = 10_000_000n;
+```
+
+### Duration
+A bigint representing time duration in milliseconds.
+
+```typescript
+const thirtyDays = 30n * 24n * 60n * 60n * 1000n; // 30 days in ms
+const ninetyDays = 90n * 24n * 60n * 60n * 1000n; // 90 days in ms
+```
+
+### StakingPosition
+Represents a locked token position.
+
+```typescript
+type StakingPosition = {
+  user: string;              // Principal as text
+  tokenId: string;           // Staked token canister ID
+  stakedAmount: bigint;      // Amount of tokens locked
+  lockStart: bigint;         // Lock start timestamp (ms)
+  lockEnd: bigint;           // Lock end timestamp (ms)
+  initialDuration: bigint;   // Original lock duration (ms)
+  remainingDuration: bigint; // Time left when last extended (ms)
+}
+```
+
+## Key Concepts
+
+### Lock Duration
+- All durations are specified in **milliseconds**
+
+### Position Rules
+- **One position per token**: Each user can have only one active position per token
+- **No modifications during lock**: Cannot unlock before expiry
+- **Increase allowed**: Can add more tokens or extend duration while locked
+
+### Withdrawals
+- Withdrawals execute immediately in a single call
+- Transfers tokens from staking canister to ODIN ledger
+- Only available balance can be withdrawn (not locked tokens)
+
+### Balances vs Positions
+- **Available balance**: Unlocked tokens, ready to stake or withdraw
+- **Staking position**: Locked tokens, cannot be withdrawn until unlocked
+
+## Next Steps
+
+- Explore [Deposits & Withdrawals](/staking/stake-deposit) for managing token transfers
+- Learn about [Staking Operations](/staking/stake-lock-tokens) for creating positions
+- Discover [Position Management](/staking/stake-increase-position) for modifying stakes
+- Review [Query Methods](/staking/queries) for reading state (indexer recommended)

--- a/docs/staking/queries.mdx
+++ b/docs/staking/queries.mdx
@@ -1,0 +1,280 @@
+---
+title: "Query Methods"
+description: "Read-only methods for querying staking balances and positions"
+---
+
+# Query Methods
+
+Query methods provide read-only access to your staking data including balances and positions.
+
+<Info>
+**Production Recommendation**: For production frontends, use the **indexer/API** for query operations instead of direct canister calls. The indexer provides better performance, caching, and filtering capabilities.
+</Info>
+
+## Architecture
+
+```
+Frontend → Indexer/API (Recommended for queries)
+         ↓
+Frontend → Staking Canister (Required for updates only)
+```
+
+## Available Query Methods
+
+### Balance Queries
+
+- **stake_get_available_balance** - Get unlocked balance for a specific token
+- **stake_get_all_available_balances** - Get all unlocked balances
+
+### Position Queries
+
+- **stake_get_position** - Get staking position for a specific token
+- **stake_get_all_positions** - Get all staking positions
+
+### System Queries
+
+- **stake_get_lock_constraints** - Get minimum and maximum lock duration constraints
+
+---
+
+## stake_get_lock_constraints
+
+Get the minimum and maximum lock duration constraints configured in the system.
+
+### Method Signature
+
+```typescript
+stake_get_lock_constraints: ActorMethod<[], {
+  minLockDurationMs: bigint;
+  maxLockDurationMs: bigint;
+}>
+```
+
+### Response
+
+Returns an object with:
+- `minLockDurationMs` - Minimum allowed lock duration in milliseconds (1 day)
+- `maxLockDurationMs` - Maximum allowed lock duration in milliseconds (configurable by admin, default: 365 days)
+
+### Example
+
+```typescript
+const constraints = await stakingActor.stake_get_lock_constraints();
+
+console.log('Min lock:', Number(constraints.minLockDurationMs) / (24 * 60 * 60 * 1000), 'days');
+console.log('Max lock:', Number(constraints.maxLockDurationMs) / (24 * 60 * 60 * 1000), 'days');
+
+// Use for validation
+const duration = 90n * 24n * 60n * 60n * 1000n; // 90 days
+
+if (duration < constraints.minLockDurationMs) {
+  console.error('Duration too short');
+} else if (duration > constraints.maxLockDurationMs) {
+  console.error('Duration too long');
+} else {
+  console.log('Duration is valid');
+}
+```
+
+---
+
+## stake_get_available_balance
+
+Get your available (unlocked) balance for a specific token.
+
+### Method Signature
+
+```typescript
+stake_get_available_balance: ActorMethod<[string], bigint>
+```
+
+### Parameters
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tokenId` | `string` | Token canister ID |
+
+### Response
+
+Returns `bigint` - Available balance (0 if none)
+
+### Example
+
+```typescript
+const tokenId = 'btc';
+const balance = await stakingActor.stake_get_available_balance(tokenId);
+console.log('Available balance:', balance); // 5_000_000n
+```
+
+---
+
+## stake_get_all_available_balances
+
+Get all available balances across all tokens.
+
+### Method Signature
+
+```typescript
+stake_get_all_available_balances: ActorMethod<[], Array<UserAvailableBalance>>
+```
+
+### Response Type
+
+```typescript
+type UserAvailableBalance = {
+  tokenId: string;
+  amount: bigint;
+}
+```
+
+### Example
+
+```typescript
+const balances = await stakingActor.stake_get_all_available_balances();
+
+balances.forEach(b => {
+  console.log(`${b.tokenId}: ${b.amount}`);
+});
+
+// Output (only non-zero balances returned):
+// btc: 5000000
+// test: 2000000
+```
+
+---
+
+## stake_get_position
+
+Get your staking position for a specific token.
+
+### Method Signature
+
+```typescript
+stake_get_position: ActorMethod<[string], StakingPosition | undefined>
+```
+
+### Parameters
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tokenId` | `string` | Token canister ID |
+
+### Response Type
+
+```typescript
+type StakingPosition = {
+  user: string;              // Principal as text
+  tokenId: string;           // Staked token canister ID
+  stakedAmount: bigint;      // Amount of tokens locked
+  lockStart: bigint;         // Lock start timestamp (ms)
+  lockEnd: bigint;           // Lock end timestamp (ms)
+  initialDuration: bigint;   // Original lock duration (ms)
+  remainingDuration: bigint; // Time left when last extended (ms)
+}
+```
+
+Returns `undefined` if no position exists.
+
+### Example
+
+```typescript
+const tokenId = 'btc';
+const position = await stakingActor.stake_get_position(tokenId);
+
+if (position) {
+  console.log('Staked amount:', position.stakedAmount);
+  console.log('Expires:', new Date(Number(position.lockEnd)));
+
+  // Check if unlocked
+  const isUnlocked = Date.now() > Number(position.lockEnd);
+  console.log('Can unlock:', isUnlocked);
+
+  // Days remaining
+  const msRemaining = Math.max(0, Number(position.lockEnd) - Date.now());
+  const daysRemaining = msRemaining / (24 * 60 * 60 * 1000);
+  console.log(`Days left: ${daysRemaining.toFixed(1)}`);
+} else {
+  console.log('No position for this token');
+}
+```
+
+---
+
+## stake_get_all_positions
+
+Get all staking positions owned by the caller.
+
+### Method Signature
+
+```typescript
+stake_get_all_positions: ActorMethod<[], Array<StakingPosition>>
+```
+
+### Response
+
+Returns `Array<StakingPosition>` - Empty array if no positions
+
+### Example
+
+```typescript
+const positions = await stakingActor.stake_get_all_positions();
+
+console.log(`Total positions: ${positions.length}`);
+
+positions.forEach(pos => {
+  const expiryDate = new Date(Number(pos.lockEnd));
+  const msRemaining = Math.max(0, Number(pos.lockEnd) - Date.now());
+  const daysRemaining = msRemaining / (24 * 60 * 60 * 1000);
+  const isUnlocked = Date.now() > Number(pos.lockEnd);
+
+  console.log(`\n${pos.tokenId}:`);
+  console.log(`  Staked: ${pos.stakedAmount}`);
+  console.log(`  Expires: ${expiryDate.toLocaleDateString()}`);
+  console.log(`  Days left: ${daysRemaining.toFixed(1)}`);
+  console.log(`  Status: ${isUnlocked ? 'Unlocked' : 'Locked'}`);
+});
+```
+
+---
+
+## Complete Portfolio Example
+
+Load all user data in a single flow:
+
+```typescript
+async function loadUserPortfolio() {
+  // Run all queries in parallel
+  const [balances, positions] = await Promise.all([
+    stakingActor.stake_get_all_available_balances(),
+    stakingActor.stake_get_all_positions()
+  ]);
+
+  return {
+    balances,  // Available to stake or withdraw
+    positions  // Currently locked
+  };
+}
+
+// Usage
+const portfolio = await loadUserPortfolio();
+
+console.log('Available Balances:');
+portfolio.balances.forEach(b => {
+  console.log(`  ${b.tokenId}: ${b.amount}`);
+});
+
+console.log('\nActive Positions:');
+portfolio.positions.forEach(p => {
+  const daysLeft = Math.max(0, Number(p.lockEnd - BigInt(Date.now()))) / (24 * 60 * 60 * 1000);
+  console.log(`  ${p.tokenId}: ${p.stakedAmount} (${daysLeft.toFixed(1)} days left)`);
+});
+```
+
+---
+
+## Related Documentation
+
+- [Deposits & Withdrawals](/staking/stake-deposit) - Manage token transfers
+- [Staking Operations](/staking/stake-lock-tokens) - Create and unlock positions
+- [Position Management](/staking/stake-increase-position) - Modify existing stakes
+- [Overview](/staking/overview) - Architecture and quick start

--- a/docs/staking/stake-deposit.mdx
+++ b/docs/staking/stake-deposit.mdx
@@ -1,0 +1,112 @@
+---
+title: "Deposit Tokens"
+description: "Deposit tokens from ODIN ledger to the staking canister"
+---
+
+# stake_deposit
+
+Transfers tokens from the ODIN ledger to your available balance in the staking canister. This is the first step before locking tokens for staking.
+
+<Info>
+Before calling `stake_deposit`, you must first approve the staking canister using ICRC-2 `approve` on the ODIN ledger.
+</Info>
+
+## Method Signature
+
+```typescript
+stake_deposit: ActorMethod<[string, bigint], { Ok: bigint } | { Err: string }>
+```
+
+## Parameters
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `tokenId` | `string` | Yes | The token canister ID to deposit |
+| `amount` | `bigint` | Yes | Amount of tokens to deposit (in smallest units) |
+
+## Response
+
+```typescript
+type DepositResponse = { Ok: bigint } | { Err: string }
+```
+
+- **Success**: `{ Ok: bigint }` - Returns the deposited amount on success
+- **Error**: `{ Err: string }` - Error message describing what went wrong
+
+## Example Usage
+
+### Complete Deposit Flow
+
+This example shows the full flow including ICRC-2 approval:
+
+```typescript
+import { Actor, HttpAgent } from "@dfinity/agent";
+import { idlFactory as OdinIdlFactory } from './odin_canister.idl';
+import { idlFactory as StakingIdlFactory } from './staking_canister.idl';
+
+const ODIN_CANISTER_ID = 'w5cxm-6iaaa-aaaaj-az4jq-cai'; // Development
+const STAKING_CANISTER_ID = 'sfgyi-iyaaa-aaaam-qepyq-cai'; // Development
+
+// Create actors
+const agent = new HttpAgent({ identity, host: 'https://ic0.app' });
+const odinActor = Actor.createActor(OdinIdlFactory, {
+  agent,
+  canisterId: ODIN_CANISTER_ID
+});
+const stakingActor = Actor.createActor(StakingIdlFactory, {
+  agent,
+  canisterId: STAKING_CANISTER_ID
+});
+
+const tokenId = 'btc';
+const depositAmount = 10_000_000n; // 10 million smallest units
+
+// Step 1: Approve the staking canister on ODIN ledger
+// NOTE: 'btc' uses default subaccount (all zeros), so from_subaccount can be omitted
+// For other tokens, include: from_subaccount: [tokenIdToSubaccount(tokenId)]
+const approveResult = await odinActor.icrc2_approve({
+  spender: {
+    owner: STAKING_CANISTER_ID,
+    subaccount: []
+  },
+  amount: depositAmount
+});
+
+// Step 2: Deposit to staking canister
+const depositResult = await stakingActor.stake_deposit(tokenId, depositAmount);
+
+if ('Ok' in depositResult) {
+  console.log('Deposited successfully:', depositResult.Ok);
+} else {
+  console.error('Deposit failed:', depositResult.Err);
+}
+```
+
+## Common Errors
+
+- **"Insufficient allowance"** - The approval amount on ODIN ledger is less than the deposit amount. Call `icrc2_approve` first with sufficient amount.
+
+- **"Transfer failed"** - The transfer from ODIN ledger to staking canister failed. Ensure you have sufficient balance on the ODIN ledger.
+
+- **"System not active"** - The staking canister is currently paused or in maintenance mode. Try again later.
+
+- **"Invalid token"** - The provided token ID is not valid or not supported by the staking canister.
+
+## What Happens Next
+
+After successful deposit:
+
+1. Tokens are transferred from ODIN ledger to the staking canister
+2. Your **available balance** increases by the deposit amount
+3. You can now [lock tokens](/staking/stake-lock-tokens) to create a staking position
+4. Or [withdraw](/staking/stake-withdraw) tokens back to ODIN ledger
+
+<Info>
+Deposited tokens are in your "available balance" - they are not staked yet. Use [stake_lock_tokens](/staking/stake-lock-tokens) to create a staking position.
+</Info>
+
+## Related Methods
+
+- [stake_withdraw](/staking/stake-withdraw) - Withdraw tokens back to ODIN ledger
+- [stake_lock_tokens](/staking/stake-lock-tokens) - Lock tokens to create staking position
+- [stake_get_available_balance](/staking/queries#stake_get_available_balance) - Check your available balance

--- a/docs/staking/stake-increase-duration.mdx
+++ b/docs/staking/stake-increase-duration.mdx
@@ -1,0 +1,230 @@
+---
+title: "Extend Lock Duration"
+description: "Extend the lock duration of an existing staking position"
+---
+
+# stake_increase_duration
+
+Extends the lock duration of an existing staking position. The new duration must be longer than the current remaining duration. The staked amount remains unchanged.
+
+**Important**: The new duration is calculated **from the current time** (when you call this method), not from the original `lockStart`. For example, if you set a 90-day duration, your position will expire 90 days from now.
+
+<Info>
+This method extends the **lock duration only**. To add more tokens to your position, use [stake_increase_position](/staking/stake-increase-position) instead.
+</Info>
+
+## Method Signature
+
+```typescript
+stake_increase_duration: ActorMethod<[string, bigint], { Ok: bigint } | { Err: string }>
+```
+
+## Parameters
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `tokenId` | `string` | Yes | The token canister ID of the existing position |
+| `newDuration` | `bigint` | Yes | New lock duration in **milliseconds** (must be > remaining duration) |
+
+## Response
+
+```typescript
+type IncreaseDurationResponse = { Ok: bigint } | { Err: string }
+```
+
+- **Success**: `{ Ok: bigint }` - Returns the new duration on success
+- **Error**: `{ Err: string }` - Error message describing what went wrong
+
+## Example Usage
+
+### Extend with Duration Check
+
+Always verify the new duration is valid before extending:
+
+```typescript
+// Helper to convert days to milliseconds
+const daysToMs = (days: number) => BigInt(days) * 24n * 60n * 60n * 1000n;
+
+// Get duration constraints from canister
+const constraints = await stakingActor.stake_get_lock_constraints();
+const MIN_LOCK_MS = constraints.minLockDurationMs;  // 1 day (86400000ms)
+const MAX_LOCK_MS = constraints.maxLockDurationMs;  // Configurable by admin
+
+const tokenId = 'btc';
+const position = await stakingActor.stake_get_position(tokenId);
+
+if (!position) {
+  console.error('No position found');
+} else {
+  const now = Date.now();
+  const remainingMs = Math.max(0, Number(position.lockEnd) - now);
+  const remainingDays = remainingMs / (24 * 60 * 60 * 1000);
+
+  console.log(`Current remaining duration: ${remainingDays.toFixed(1)} days`);
+
+  // New duration: extend to 180 days from now
+  const newDurationDays = 180;
+  const newDurationMs = daysToMs(newDurationDays);
+
+  // Validate new duration
+  if (newDurationMs <= BigInt(remainingMs)) {
+    console.error(`New duration must be > ${remainingDays.toFixed(1)} days`);
+  } else if (newDurationMs < MIN_LOCK_MS) {
+    console.error('Duration must be at least 1 day');
+  } else if (newDurationMs > MAX_LOCK_MS) {
+    console.error('Duration exceeds maximum allowed (365 days)');
+  } else {
+    const result = await stakingActor.stake_increase_duration(tokenId, newDurationMs);
+
+    if ('Ok' in result) {
+      console.log(`Extended to ${newDurationDays} days from now`);
+
+      const updatedPosition = await stakingActor.stake_get_position(tokenId);
+      const newExpiryDate = new Date(Number(updatedPosition.lockEnd));
+      console.log(`New expiry: ${newExpiryDate.toLocaleString()}`);
+    } else {
+      console.error('Extension failed:', result.Err);
+    }
+  }
+}
+```
+
+## Common Errors
+
+- **"Position not found"** - No staking position exists for this token. Use [stake_lock_tokens](/staking/stake-lock-tokens) to create a position first.
+
+- **"New duration not longer"** - The new duration must be greater than the current remaining duration (0 for expired positions). Increase the duration value.
+
+- **"Duration too long"** - The new duration exceeds the maximum allowed lock duration. Reduce the duration.
+
+## Important Notes
+
+### Duration Requirements
+
+The new duration must be:
+- ✅ **Longer** than current remaining duration (0 for expired positions)
+- ✅ **At least** 1 day (minimum lock duration)
+- ✅ **At most** 365 days (maximum lock duration, configurable by admin)
+- ❌ Cannot be shorter than remaining duration
+- ❌ Cannot be same as current remaining duration
+
+### Calculating New Duration
+
+```typescript
+const position = await stakingActor.stake_get_position(tokenId);
+const now = Date.now();
+
+// Current remaining duration
+const remainingMs = Math.max(0, Number(position.lockEnd) - now);
+const remainingDays = remainingMs / (24 * 60 * 60 * 1000);
+
+console.log(`Currently ${remainingDays.toFixed(1)} days remaining`);
+
+// New duration must be longer
+const newDurationDays = Math.ceil(remainingDays) + 30; // Add 30 days
+const newDurationMs = BigInt(newDurationDays) * 24n * 60n * 60n * 1000n;
+```
+
+### Amount Unchanged
+
+When you extend duration:
+- ✅ `lockEnd` extended (pushed forward)
+- ✅ `remainingDuration` increased
+- ✅ `initialDuration` may be updated
+- ❌ `stakedAmount` stays the same
+
+To add more tokens instead, use [stake_increase_position](/staking/stake-increase-position).
+
+### Extending Expired Positions
+
+You can extend both active AND expired positions:
+
+```typescript
+const position = await stakingActor.stake_get_position(tokenId);
+const now = Date.now();
+const isExpired = now >= Number(position.lockEnd);
+
+if (isExpired) {
+  // Expired position: remainingDuration = 0, any new duration > 0 works
+  const newDuration = 30n * 24n * 60n * 60n * 1000n; // 30 days
+  await stakingActor.stake_increase_duration(tokenId, newDuration);
+  console.log('Extended expired position with new 30-day lock');
+} else {
+  // Active position: new duration must be > remaining duration
+  const remainingMs = Number(position.lockEnd) - now;
+  const newDurationMs = BigInt(remainingMs) + (60n * 24n * 60n * 60n * 1000n); // +60 days
+  await stakingActor.stake_increase_duration(tokenId, newDurationMs);
+  console.log('Extended active position');
+}
+```
+
+### Combining Duration Extension and Token Addition
+
+If you want to both extend the lock duration AND add more tokens to a position, the order of operations depends on whether the position is expired:
+
+**For active positions**: Either order works
+- Extend duration first, then add tokens ✅
+- Add tokens first, then extend duration ✅
+
+**For expired positions**: Must extend duration first
+- Extend duration first, then add tokens ✅
+- Cannot add tokens to expired position ❌
+
+```typescript
+const tokenId = 'btc';
+const additionalAmount = 1_000_000n;
+const newDuration = 90n * 24n * 60n * 60n * 1000n; // 90 days
+
+// Get current position
+const position = await stakingActor.stake_get_position(tokenId);
+const now = Date.now();
+const isExpired = now >= Number(position.lockEnd);
+
+if (isExpired) {
+  // EXPIRED: Must extend duration first to reactivate
+  console.log('Position expired. Extending duration first...');
+
+  // Step 1: Extend duration to reactivate
+  const extendResult = await stakingActor.stake_increase_duration(tokenId, newDuration);
+
+  if ('Ok' in extendResult) {
+    console.log('Duration extended. Position is now active.');
+
+    // Step 2: Now can add tokens
+    const increaseResult = await stakingActor.stake_increase_position(tokenId, additionalAmount);
+
+    if ('Ok' in increaseResult) {
+      console.log('Tokens added successfully');
+      console.log('New total staked:', increaseResult.Ok);
+    }
+  }
+} else {
+  // ACTIVE: Either order works
+  console.log('Position is active. Can use any order.');
+
+  // Option A: Add tokens first, then extend
+  await stakingActor.stake_increase_position(tokenId, additionalAmount);
+  await stakingActor.stake_increase_duration(tokenId, newDuration);
+
+  // Option B: Extend first, then add tokens (also works)
+  // await stakingActor.stake_increase_duration(tokenId, newDuration);
+  // await stakingActor.stake_increase_position(tokenId, additionalAmount);
+}
+```
+
+## What Happens Next
+
+After successful extension:
+
+1. **Lock end updated**: `lockEnd` = `now + newDuration`
+2. **Remaining duration updated**: Reflects new time until expiry
+3. **Staked amount unchanged**: Same number of tokens locked
+
+The position continues with the same staked amount but an extended lock period.
+
+## Related Methods
+
+- [stake_lock_tokens](/staking/stake-lock-tokens) - Create a new position
+- [stake_increase_position](/staking/stake-increase-position) - Add more tokens
+- [stake_unlock](/staking/stake-unlock) - Unlock expired position
+- [stake_get_position](/staking/queries#stake_get_position) - Check current position

--- a/docs/staking/stake-increase-position.mdx
+++ b/docs/staking/stake-increase-position.mdx
@@ -1,0 +1,144 @@
+---
+title: "Increase Position Amount"
+description: "Add more tokens to an existing staking position without changing the lock duration"
+---
+
+# stake_increase_position
+
+Increases the staked amount of an existing position by adding more tokens from your available balance. The lock duration and expiry time remain unchanged.
+
+<Info>
+This method adds tokens to an **existing position only**. To create a new position, use [stake_lock_tokens](/staking/stake-lock-tokens) instead.
+</Info>
+
+## Method Signature
+
+```typescript
+stake_increase_position: ActorMethod<[string, bigint], { Ok: bigint } | { Err: string }>
+```
+
+## Parameters
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `tokenId` | `string` | Yes | The token canister ID of the existing position |
+| `additionalAmount` | `bigint` | Yes | Additional tokens to add to the position (in smallest units) |
+
+## Response
+
+```typescript
+type IncreasePositionResponse = { Ok: bigint } | { Err: string }
+```
+
+- **Success**: `{ Ok: bigint }` - Returns the new total staked amount on success
+- **Error**: `{ Err: string }` - Error message describing what went wrong
+
+## Example Usage
+
+### Increase with Balance Check
+
+Always verify sufficient balance before increasing:
+
+```typescript
+const tokenId = 'btc';
+const additionalAmount = 1_000_000n;
+
+// Check available balance
+const balance = await stakingActor.stake_get_available_balance(tokenId);
+
+if (balance < additionalAmount) {
+  console.error(`Insufficient balance. Have: ${balance}, Need: ${additionalAmount}`);
+} else {
+  // Get current position
+  const position = await stakingActor.stake_get_position(tokenId);
+
+  if (!position) {
+    console.error('No position found. Use stake_lock_tokens to create one.');
+  } else {
+    console.log('Current staked:', position.stakedAmount);
+
+    // Increase position
+    const result = await stakingActor.stake_increase_position(tokenId, additionalAmount);
+
+    if ('Ok' in result) {
+      console.log('New total staked:', result.Ok);
+      console.log('Added:', additionalAmount);
+
+      // Check remaining balance
+      const newBalance = await stakingActor.stake_get_available_balance(tokenId);
+      console.log('Remaining available:', newBalance);
+    }
+  }
+}
+```
+
+## Common Errors
+
+- **"Position not found"** - No staking position exists for this token. Use [stake_lock_tokens](/staking/stake-lock-tokens) to create a position first.
+
+- **"Insufficient balance"** - You don't have enough available balance. [Deposit](/staking/stake-deposit) more tokens first or reduce the increase amount.
+
+- **"Position expired"** - The position's lock period has already ended. To add tokens to an expired position, first [extend the duration](/staking/stake-increase-duration#combining-duration-extension-and-token-addition) to reactivate it, then add tokens. Alternatively, [unlock](/staking/stake-unlock) the expired position and create a new one with [stake_lock_tokens](/staking/stake-lock-tokens).
+
+- **"System not active"** - The staking canister is currently paused. Try again later.
+
+- **"Amount must be greater than zero"** - The additional amount must be positive.
+
+## Important Notes
+
+### Duration Unchanged
+
+When you increase a position:
+- ✅ `stakedAmount` increases
+- ✅ Available balance decreases
+- ❌ `lockEnd` stays the same (no extension)
+- ❌ `initialDuration` stays the same
+
+To extend the lock duration instead, use [stake_increase_duration](/staking/stake-increase-duration).
+
+### Position Must Be Active
+
+You can only increase **active** positions (not expired):
+
+```typescript
+const position = await stakingActor.stake_get_position(tokenId);
+const isActive = Date.now() < Number(position.lockEnd);
+
+if (isActive) {
+  // Can increase
+  await stakingActor.stake_increase_position(tokenId, amount);
+} else {
+  // Position expired - extend duration first to reactivate
+  // See: stake_increase_duration for combining operations
+  console.error('Position expired. Extend duration first or unlock and create new position.');
+}
+```
+
+### Use Cases
+
+**When to use `stake_increase_position`:**
+- Add more tokens to an existing stake
+
+**When NOT to use:**
+- Creating a new position → Use [stake_lock_tokens](/staking/stake-lock-tokens)
+- Extending lock duration → Use [stake_increase_duration](/staking/stake-increase-duration)
+- Position already expired → [Extend duration](/staking/stake-increase-duration#combining-duration-extension-and-token-addition) first to reactivate
+
+## What Happens Next
+
+After successful increase:
+
+1. **Additional tokens locked**: Tokens move from available balance to position
+2. **Position updated**:
+   - `stakedAmount` = previous amount + additional amount
+   - `lockEnd` remains unchanged
+   - `initialDuration` remains unchanged
+3. **Available balance** decreases by additional amount
+
+## Related Methods
+
+- [stake_lock_tokens](/staking/stake-lock-tokens) - Create a new position
+- [stake_increase_duration](/staking/stake-increase-duration) - Extend lock duration
+- [stake_unlock](/staking/stake-unlock) - Unlock expired position
+- [stake_get_position](/staking/queries#stake_get_position) - Check current position
+- [stake_deposit](/staking/stake-deposit) - Deposit tokens first

--- a/docs/staking/stake-lock-tokens.mdx
+++ b/docs/staking/stake-lock-tokens.mdx
@@ -1,0 +1,130 @@
+---
+title: "Lock Tokens"
+description: "Create a new staking position by locking tokens for a specified duration"
+---
+
+# stake_lock_tokens
+
+<Info>
+You can only have **one staking position per token**. If you already have a position for a token, use [stake_increase_position](/staking/stake-increase-position) or [stake_increase_duration](/staking/stake-increase-duration) instead.
+</Info>
+
+## Method Signature
+
+```typescript
+stake_lock_tokens: ActorMethod<[string, bigint, bigint], { Ok: bigint } | { Err: string }>
+```
+
+## Parameters
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `tokenId` | `string` | Yes | The token canister ID to stake |
+| `amount` | `bigint` | Yes | Amount of tokens to lock (in smallest units) |
+| `duration` | `bigint` | Yes | Lock duration in **milliseconds** |
+
+## Response
+
+```typescript
+type LockResponse = { Ok: bigint } | { Err: string }
+```
+
+- **Success**: `{ Ok: bigint }` - Returns the locked amount on success
+- **Error**: `{ Err: string }` - Error message describing what went wrong
+
+## Example Usage
+
+### Complete Flow: Deposit → Lock
+
+```typescript
+// Helper to convert days to milliseconds
+const daysToMs = (days: number) => BigInt(days) * 24n * 60n * 60n * 1000n;
+
+// Get duration constraints from canister
+const constraints = await stakingActor.stake_get_lock_constraints();
+const MIN_LOCK_MS = constraints.minLockDurationMs;  // 1 day (86400000ms)
+const MAX_LOCK_MS = constraints.maxLockDurationMs;  // Configurable by admin
+
+const tokenId = 'btc';
+const depositAmount = 10_000_000n;
+const lockAmount = 7_000_000n;
+const duration = daysToMs(90); // 90 days
+
+// Validate duration
+if (duration < MIN_LOCK_MS) {
+  console.error('Duration must be at least 1 day');
+} else if (duration > MAX_LOCK_MS) {
+  console.error('Duration exceeds maximum allowed (365 days)');
+} else {
+  // Step 1: Approve on ODIN
+  // NOTE: 'btc' uses default subaccount, so from_subaccount can be omitted
+  // For other tokens, include: from_subaccount: [tokenIdToSubaccount(tokenId)]
+  await odinActor.icrc2_approve({
+    spender: { owner: STAKING_CANISTER_ID, subaccount: [] },
+    amount: depositAmount
+  });
+
+  // Step 2: Deposit to staking canister
+  await stakingActor.stake_deposit(tokenId, depositAmount);
+
+  // Step 3: Check available balance
+  const balance = await stakingActor.stake_get_available_balance(tokenId);
+
+  if (balance < lockAmount) {
+    console.error(`Insufficient balance. Have: ${balance}, Need: ${lockAmount}`);
+  } else {
+    // Step 4: Lock tokens
+    const lockResult = await stakingActor.stake_lock_tokens(tokenId, lockAmount, duration);
+
+    if ('Ok' in lockResult) {
+      console.log('Staking position created successfully');
+      console.log(`Locked: ${lockAmount}`);
+
+      // Check remaining balance
+      const newBalance = await stakingActor.stake_get_available_balance(tokenId);
+      console.log(`Remaining available: ${newBalance}`);
+    } else {
+      console.error('Lock failed:', lockResult.Err);
+    }
+  }
+}
+```
+
+## Common Errors
+
+- **"Insufficient balance"** - You don't have enough available balance. [Deposit](/staking/stake-deposit) more tokens first or reduce the lock amount.
+
+- **"Position already exists"** - You already have an active staking position for this token. Use [stake_increase_position](/staking/stake-increase-position) to add more tokens or [stake_increase_duration](/staking/stake-increase-duration) to extend the lock.
+
+- **"Invalid duration"** - The duration is outside the allowed range. Check system configuration for minimum and maximum lock durations.
+
+- **"Duration too short"** - The lock duration is below the minimum required. Increase the duration.
+
+- **"Duration too long"** - The lock duration exceeds the maximum allowed. Reduce the duration.
+
+- **"System not active"** - The staking canister is currently paused. Try again later.
+
+## Important Notes
+
+### Lock Duration
+- Duration must be in **milliseconds**, not seconds or days
+- Once locked, tokens cannot be unlocked early
+
+### One Position Per Token
+You can have multiple positions across different tokens, but only one position per token.
+
+## What Happens Next
+
+After successful lock:
+
+1. A **staking position** is created for the token
+2. Tokens move from available balance to locked state
+3. To unlock: wait until lock expires, then call [stake_unlock](/staking/stake-unlock)
+
+## Related Methods
+
+- [stake_unlock](/staking/stake-unlock) - Unlock expired position
+- [stake_increase_position](/staking/stake-increase-position) - Add more tokens to position
+- [stake_increase_duration](/staking/stake-increase-duration) - Extend lock duration
+- [stake_get_position](/staking/queries#stake_get_position) - Check your position
+- [stake_deposit](/staking/stake-deposit) - Deposit tokens first

--- a/docs/staking/stake-unlock.mdx
+++ b/docs/staking/stake-unlock.mdx
@@ -1,0 +1,141 @@
+---
+title: "Unlock Position"
+description: "Unlock an expired staking position and return tokens to available balance"
+---
+
+# stake_unlock
+
+<Info>
+You can only unlock a position **after** the lock period has expired. Early unlocking is not possible.
+</Info>
+
+## Method Signature
+
+```typescript
+stake_unlock: ActorMethod<[string], { Ok: bigint } | { Err: string }>
+```
+
+## Parameters
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `tokenId` | `string` | Yes | The token canister ID of the position to unlock |
+
+## Response
+
+```typescript
+type UnlockResponse = { Ok: bigint } | { Err: string }
+```
+
+- **Success**: `{ Ok: bigint }` - Returns the unlocked amount on success
+- **Error**: `{ Err: string }` - Error message describing what went wrong
+
+## Example Usage
+
+### Unlock with Expiry Check
+
+Always verify the position has expired before unlocking:
+
+```typescript
+const tokenId = 'btc';
+
+// Get the position
+const position = await stakingActor.stake_get_position(tokenId);
+
+if (!position) {
+  console.error('No position found');
+} else {
+  const now = Date.now();
+  const lockEnd = Number(position.lockEnd);
+
+  if (lockEnd > now) {
+    // Not expired yet
+    const msRemaining = lockEnd - now;
+    const daysRemaining = msRemaining / (24 * 60 * 60 * 1000);
+    console.log(`Lock expires in ${daysRemaining.toFixed(1)} days`);
+    console.log(`Expiry date: ${new Date(lockEnd).toLocaleString()}`);
+  } else {
+    // Expired, can unlock
+    const result = await stakingActor.stake_unlock(tokenId);
+
+    if ('Ok' in result) {
+      console.log(`Unlocked ${result.Ok} tokens`);
+    }
+  }
+}
+```
+
+## Common Errors
+
+- **"Position not found"** - No staking position exists for this token. Use [stake_lock_tokens](/staking/stake-lock-tokens) to create one first.
+
+- **"Lock not expired"** - The lock period hasn't ended yet. You must wait until `lockEnd` timestamp before unlocking.
+
+- **"System not active"** - The staking canister is currently paused. Try again later.
+
+## Important Notes
+
+### No Early Unlock
+
+Once tokens are locked, they **cannot be unlocked early**:
+
+- ✅ Can unlock after `lockEnd` timestamp
+- ❌ Cannot unlock before `lockEnd` timestamp
+- ❌ No emergency unlock option
+
+Plan your lock duration carefully!
+
+### Checking Expiry
+
+To check if a position can be unlocked:
+
+```typescript
+const position = await stakingActor.stake_get_position(tokenId);
+const canUnlock = Date.now() > Number(position.lockEnd);
+```
+
+Or calculate time remaining:
+
+```typescript
+const msRemaining = Math.max(0, Number(position.lockEnd) - Date.now());
+const daysRemaining = msRemaining / (24 * 60 * 60 * 1000);
+
+console.log(`Days until unlock: ${daysRemaining.toFixed(2)}`);
+```
+
+### What Happens After Unlock
+
+1. Staking position is **removed** from storage
+2. Locked amount returns to **available balance**
+3. You can now [withdraw](/staking/stake-withdraw) or [lock again](/staking/stake-lock-tokens)
+
+### Position Status
+
+After unlock, querying the position returns `undefined`:
+
+```typescript
+// Before unlock
+const position = await stakingActor.stake_get_position('btc');
+console.log(position); // { user: '...', stakedAmount: 5000000n, ... }
+
+// After unlock
+await stakingActor.stake_unlock('btc');
+const positionAfter = await stakingActor.stake_get_position('btc');
+console.log(positionAfter); // undefined
+```
+
+## What Happens Next
+
+After successful unlock:
+
+1. **Staking position deleted**: The position record is removed
+2. **Tokens available**: Unlocked amount added to available balance
+3. **Can re-stake**: Create a new position with [stake_lock_tokens](/staking/stake-lock-tokens)
+4. **Can withdraw**: Transfer tokens back to ODIN with [stake_withdraw](/staking/stake-withdraw) (immediate execution)
+
+## Related Methods
+
+- [stake_lock_tokens](/staking/stake-lock-tokens) - Create a new staking position
+- [stake_withdraw](/staking/stake-withdraw) - Withdraw unlocked tokens to ODIN
+- [stake_get_position](/staking/queries#stake_get_position) - Check position status
+- [stake_get_available_balance](/staking/queries#stake_get_available_balance) - Check available balance

--- a/docs/staking/stake-withdraw.mdx
+++ b/docs/staking/stake-withdraw.mdx
@@ -1,0 +1,132 @@
+---
+title: "Withdraw Tokens"
+description: "Withdraw tokens from the staking canister back to ODIN ledger"
+---
+
+# stake_withdraw
+
+Transfers tokens from your available balance in the staking canister back to the ODIN ledger. Withdrawals execute immediately in a single operation.
+
+## Method Signature
+
+```typescript
+stake_withdraw: ActorMethod<[string, bigint], { Ok: bigint } | { Err: string }>
+```
+
+## Parameters
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `tokenId` | `string` | Yes | The token canister ID to withdraw |
+| `amount` | `bigint` | Yes | Amount of tokens to withdraw |
+
+## Response
+
+```typescript
+type WithdrawResponse = { Ok: bigint } | { Err: string }
+```
+
+- **Success**: `{ Ok: bigint }` - Returns the withdrawn amount on success
+- **Error**: `{ Err: string }` - Error message describing what went wrong
+
+## Example Usage
+
+### Withdrawal with Balance Check
+
+Always verify sufficient balance before withdrawing:
+
+```typescript
+const tokenId = 'btc';
+const withdrawAmount = 5_000_000n;
+
+// Check available balance first
+const balance = await stakingActor.stake_get_available_balance(tokenId);
+
+if (balance < withdrawAmount) {
+  console.error(`Insufficient balance. Have: ${balance}, Need: ${withdrawAmount}`);
+} else {
+  // Execute withdrawal
+  const result = await stakingActor.stake_withdraw(tokenId, withdrawAmount);
+
+  if ('Ok' in result) {
+    console.log(`Withdrew ${result.Ok} tokens`);
+
+    // Verify new balance
+    const newBalance = await stakingActor.stake_get_available_balance(tokenId);
+    console.log(`Remaining balance: ${newBalance}`);
+  }
+}
+```
+
+## Common Errors
+
+- **"Insufficient balance"** - You don't have enough available balance. Check your balance with `stake_get_available_balance` or [unlock](/staking/stake-unlock) staked tokens first.
+
+- **"Transfer failed"** - The transfer back to ODIN ledger failed. This could be due to ODIN canister issues or network problems.
+
+- **"Invalid token ID"** or **"Invalid amount"** - The token ID or amount parameter is invalid. Amount must be greater than zero.
+
+## Important Notes
+
+### Available Balance Only
+
+You can only withdraw tokens from your **available balance**:
+
+- ✅ Deposited tokens (not yet staked)
+- ✅ Unlocked tokens (after calling `stake_unlock`)
+- ❌ Locked tokens (in active staking positions)
+
+To withdraw locked tokens:
+1. Wait for lock period to expire
+2. Call [stake_unlock](/staking/stake-unlock) to return tokens to available balance
+3. Call `stake_withdraw` to transfer to ODIN ledger
+
+### Immediate Execution
+
+Withdrawals execute immediately:
+- ✅ Single call completes the operation
+- ✅ Tokens transferred instantly to ODIN ledger
+- ✅ No waiting period or delay
+- ✅ Balance updated immediately
+
+### Withdrawal Process
+
+When you call `stake_withdraw`:
+
+1. **Validation**: Checks available balance is sufficient
+2. **Reserve**: Decreases available balance and creates pending withdrawal record
+3. **Transfer**: Transfers tokens from staking canister to ODIN ledger
+4. **Complete**: Removes pending record and returns success with withdrawn amount
+
+If the transfer fails, the available balance is refunded automatically.
+
+### Balance After Withdrawal
+
+```typescript
+// Before
+const before = await stakingActor.stake_get_available_balance('btc');
+console.log('Before:', before); // 10_000_000n
+
+// Withdraw
+await stakingActor.stake_withdraw('btc', 7_000_000n);
+
+// After
+const after = await stakingActor.stake_get_available_balance('btc');
+console.log('After:', after); // 3_000_000n
+```
+
+## What Happens Next
+
+After successful withdrawal:
+
+1. **Tokens transferred**: Moved from staking canister to ODIN ledger
+2. **Available balance decreased**: Reduced by withdrawal amount
+3. **ODIN balance increased**: Tokens now in your ODIN account
+4. **Can deposit again**: Free to [deposit](/staking/stake-deposit) and stake again anytime
+
+## Related Methods
+
+- [stake_deposit](/staking/stake-deposit) - Deposit tokens from ODIN ledger
+- [stake_unlock](/staking/stake-unlock) - Unlock staked tokens to available balance
+- [stake_get_available_balance](/staking/queries#stake_get_available_balance) - Check available balance
+- [stake_lock_tokens](/staking/stake-lock-tokens) - Stake available balance


### PR DESCRIPTION
## Summary
- Add comprehensive canister documentation: token mint, swap, liquidity, deposit, list, get-balance, get-token, voucher-claim, access-grant, error handling, and configuration reference
- Add staking canister documentation: stake lock, deposit, withdraw, unlock, increase position/duration, and query methods
- Update canister overview and docs.json navigation structure
- Add under-development warning to staking section

## Test plan
- [ ] Verify all new doc pages render correctly
- [ ] Confirm navigation links in docs.json work as expected
- [ ] Check internal cross-references between pages